### PR TITLE
update the store command to support multiple storers

### DIFF
--- a/action/store.go
+++ b/action/store.go
@@ -129,7 +129,7 @@ var storeCmd = &cobra.Command{
 }
 
 func init() {
-	storeCmd.Flags().StringVarP(&storeFlags.storerName, "storer", "", "sql", fmt.Sprintf("storer name. supported options: %v", registeredStorerNames))
+	storeCmd.Flags().StringVarP(&storeFlags.storerName, "storer", "", "psql", fmt.Sprintf("storer name. supported options: %v", registeredStorerNames))
 	storeCmd.Flags().StringVarP(&storeFlags.repo, "repo", "g", "", "repository name")
 	storeCmd.Flags().StringVarP(&storeFlags.branch, "branch", "b", "master", "branch name")
 	storeCmd.Flags().Int64VarP(&storeFlags.buildID, "build-id", "i", 0, "build id")

--- a/gocop/storer/psql_test.go
+++ b/gocop/storer/psql_test.go
@@ -50,7 +50,7 @@ func TestInsertResults(t *testing.T) {
 		Result:   "fail",
 		Created:  run.Created,
 		Duration: time.Second,
-		Coverage: 88.0,
+		Coverage: 0.834,
 	}
 
 	testResults = append(testResults, result)


### PR DESCRIPTION

```
╰─❯ go unn . store --help
stores test results to database

Usage:
  gocop store [flags]

Flags:
      --bench                 indicate if test ran benchmarks
  -b, --branch string         branch name (default "master")
  -i, --build-id int          build id
  -c, --cmd string            test execution command
  -h, --help                  help for store
      --race                  indicate if test is run with -race flag
  -g, --repo string           repository name
  -r, --rerun strings         comma-separated source output for retests
  -z, --sha string            git sha of test run
      --short                 indicate if test is run with -short flag
      --sql.database string   database name (default "postgres")
      --sql.host string       database host (default "localhost")
      --sql.pass string       database password
      --sql.port string       database port (default "5432")
      --sql.ssl string        database ssl mode (default "require")
      --sql.user string       database username (default "postgres")
  -s, --src string            source test output file
      --storer string         storer name. supported options: [sql] (default "sql")
      --tags strings          comma-separated tags enabled for the run
  -m, --time string           time of test run

```